### PR TITLE
Centos8: missing krbclient vars

### DIFF
--- a/roles/openafs_krbclient/vars/CentOS-8.yaml
+++ b/roles/openafs_krbclient/vars/CentOS-8.yaml
@@ -1,0 +1,6 @@
+---
+# Kerberos client files
+afs_krbclient_krb5_conf: "/etc/krb5.conf"
+
+# OS dependent variables
+afs_firewall: firewalld


### PR DESCRIPTION
Fix problem with missing variable afs_krbclient_krb5_conf